### PR TITLE
Revert "Developer tools" heading

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -287,8 +287,8 @@ nav:
       - Overview: miden/overview.md
       - Miden zkRollup docs: https://0xpolygonmiden.github.io/miden-base/introduction.html
       - Miden VM docs: https://0xpolygonmiden.github.io/miden-vm/
-  - Developer tools: 
-      - Developer tools: tools/index.md
+  - Tools: 
+      - Tools: tools/index.md
       - Smart contract development: 
           - Hardhat: tools/smart-contracts/hardhat.md
           - Truffle: tools/smart-contracts/truffle.md


### PR DESCRIPTION
Right now, "Developer tools" is taking up double the size of the second-largest section and triple the average size of all other sections in the navigation bar.

<img width="672" alt="image" src="https://github.com/0xPolygon/polygon-docs/assets/9953/bf6864ce-b912-47ce-93b6-8b8d4f1b0faf">


- Home: 3 squares
- CDK: 2 squares
- zkEVM: 4 squares
- PoS: 2 squares
- Miden: 3 squares
- Developer tools: 8 squares
- Learn: 3 squares

It's not appropriate design to have a miscellaneous section take up triple the average navigation size of the main product sections.

Please accept this commit to revert the change.