### PR TITLE
Update configure-prover.md - edit the prover file in the correct space

### DIFF
--- a/docs/zkEVM/get-started/deploy-zkevm/configure-prover.md
+++ b/docs/zkEVM/get-started/deploy-zkevm/configure-prover.md
@@ -33,7 +33,7 @@ Save and exit the file once the changes have been made. The above SQL script wil
 Create the `~/zkevm/config.json` and paste the configs below. Replace the `aggregatorClientHost` parameter with your **PUBLIC IP**:
 
 ```bash
-vim ~/zkevm/config.json
+vim ~/zkevm/mainnet/config/environments/testnet/public.prover.config.json
 ```
 
 ??? "Click to expand the <code>config.json</code> file"


### PR DESCRIPTION
If I am looking into the docker-compose, then in no place, the vim ~/zkevm/config.json is used. Hence, I am pretty sure, that we want to edit the file that is use in the zkevm-prover of the docker-compose