### PR TITLE
[Updated] Analytics Tracking Method

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -566,8 +566,8 @@ nav:
 extra:
   generator: false
   analytics:
-    provider: google
-    property: G-RJ6JC0EEY5
+    provider: custom
+    property: google    
   #  feedback:  # feedback form only works when Google Analytics is set up and working
   #    title: Was this page helpful?
   #    ratings:


### PR DESCRIPTION
I changed the analytics tracking method from plain Google Analytics to GTM-based tracking.
This is done so that the partial override file we have added in the repo gets loaded on the `docs.polygon.technology` website. 


