### PR TITLE
Highlight menu headers

### DIFF
--- a/docs/_site_essentials/stylesheets/extra.css
+++ b/docs/_site_essentials/stylesheets/extra.css
@@ -1,27 +1,3 @@
-[data-md-color-scheme="slate"] {
-	--md-footer-bg-color: black;
-
-	.md-footer,
-	.md-footer__inner,
-	.md-footer-meta {
-		background-color: black;
-	}
-}
-
-[data-md-color-scheme="default"] {
-	--md-footer-bg-color: white;
-	--md-footer-fg-color: charcoal;
-	--md-default-bg-color: white;
-	--md-footer-fg-color--light: charcoal;
-	--md-footer-fg-color--lighter: charcoal;
-
-	.md-footer,
-	.md-footer__inner,
-	.md-footer-meta {
-		background-color: white;
-	}
-}
-
 img.figure {
 	margin: 0 auto;
 	display: block;

--- a/docs/_site_essentials/stylesheets/polygon-docs.webflow.css
+++ b/docs/_site_essentials/stylesheets/polygon-docs.webflow.css
@@ -1,10 +1,49 @@
 :root {
 	--smoke-white: #f8f8f8;
 	--main-black: #110c22;
-	--gray-light: #8d8a95;
+	--gray-light: #110c22;
 	--white: white;
 	--gray: #4f4b5c;
 	--purple: #773ef0;
+
+	--md-text-font: Generalsans;
+	--md-code-font: roboto mono;
+
+	--md-primary-bg-color: #f8f8f8;
+	--md-primary-bg-color--light: white;
+	--md-primary-fg-color: #110c22;
+}
+
+.md-footer, .md-footer__inner, .md-footer-meta, .md-copyright__highlight, .md-social__link {
+	background-color: white;
+	color: var(--main-black) !important;
+}
+
+.md-search__input {
+	background-color: var(--smoke-white) !important;
+}
+
+.md-nav>.md-nav__title {
+	color: var(--purple) !important;
+	background-color: var(--smoke-white) !important;
+	margin: 0 !important;
+	padding: 0 !important;
+}
+
+.md-sidebar__scrollwrap, .md-sidebar__inner {
+	background-color: var(--smoke-white) !important;
+	margin: 0 !important;
+	padding: 0 !important;
+}
+
+.md-nav__link, .md-nav__link>.md-ellipsis {
+	color: var(--main-black) !important;
+	background-color: var(--smoke-white) !important;
+}
+
+.md-nav__link>.md-nav__link--active {
+	margin: 0 !important;
+	padding: 0 !important;
 }
 
 h1 {
@@ -31,7 +70,7 @@ div.main h1 {
 	margin-top: 0 !important;
 }
 
-div.main h3 {
+div.main h2 {
 	margin-top: 0 !important;
 }
 
@@ -73,7 +112,7 @@ div.main div.flexbox a {
 }
 
 div.main .nav-bar {
-	background-color: var(--white);
+	background-color: var(--smoke-white);
 	border-bottom: 1px solid rgba(0, 0, 0, .12);
 	padding: 10px 108px;
 }
@@ -114,10 +153,6 @@ div.main .nav-content {
 	justify-content: space-between;
 	align-items: flex-start;
 	display: flex;
-}
-
-div.main .section {
-
 }
 
 .hero-content-flex {
@@ -162,7 +197,7 @@ div.main .section {
 	max-width: 400px;
 }
 
-.hero-subext {
+.hero-subtext {
 	color: var(--gray);
 	font-weight: 500;
 }
@@ -229,7 +264,8 @@ div.main .section {
 	line-height: 1.6;
 }
 
-.feature-card-heading {
+.feature-card-heading, .md-typeset a {
+	color: --purple;
 	font-size: 18px;
 	font-weight: 600;
 }
@@ -510,7 +546,7 @@ div.main .section {
 
 	.nav-menu {
 		width: 90vw;
-		background-color: var(--white);
+		background-color: var(--smoke-white);
 		flex-direction: column;
 		padding: 80px 24px 24px;
 	}
@@ -597,7 +633,7 @@ div.main .section {
 
 	.nav-menu-btn.w--open {
 		z-index: 5;
-		background-color: var(--white);
+		background-color: var(--smoke-white);
 	}
 
 	.menu-icon {
@@ -750,37 +786,4 @@ div.main .section {
 	.nav-brand.w--current {
 		padding-left: 0;
 	}
-}
-
-
-@font-face {
-	font-family: 'Generalsans';
-	src: url('../fonts/GeneralSans-Semibold.woff2') format('woff2');
-	font-weight: 600;
-	font-style: normal;
-	font-display: swap;
-}
-
-@font-face {
-	font-family: 'Generalsans';
-	src: url('../fonts/GeneralSans-Medium.woff2') format('woff2');
-	font-weight: 500;
-	font-style: normal;
-	font-display: swap;
-}
-
-@font-face {
-	font-family: 'Generalsans';
-	src: url('../fonts/GeneralSans-Bold.woff2') format('woff2');
-	font-weight: 700;
-	font-style: normal;
-	font-display: swap;
-}
-
-@font-face {
-	font-family: 'Generalsans';
-	src: url('../fonts/GeneralSans-Regular.woff2') format('woff2');
-	font-weight: 400;
-	font-style: normal;
-	font-display: swap;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,18 +9,14 @@ site_url: https://docs.polygon.technology/
 theme:
   name: material
   palette:
-    - scheme: default
       primary: white
-      accent: purple
+      accent: deep purple
   language: en
   custom_dir: overrides
   favicon: img/favicon.ico
   icon:
     logo: logo
     repo: repo
-  font:
-    text: Roboto
-    code: Roboto Mono
   features:
     - search.suggest
     - search.highlight
@@ -324,8 +320,6 @@ nav:
             - EIP-1559: pos/concepts/transactions/eip-1559.md
             - EIP-4337: pos/concepts/transactions/eip-4337.md
             - Meta-transactions: pos/concepts/transactions/meta-transactions.md
-    #  - API:
-    #      - pos/api/index.md
   - Miden:
       - Miden: miden/index.md
       - Overview: miden/overview.md


### PR DESCRIPTION
This PR was originally just supposed to be about changing the grey on menu headers to black.

However, I realized that most, if not all, of the designer css was being ignored by the docs platform due to the way it is set up, so I fixed a few other things too, including:

- Fonts across the site.
- Coloring.
- Background colors.
- Menu headers themselves -> which was extremely tricky and there is still an issue.

OUTSTANDING ISSUES:

- There is still a white border around the menu top heading on both sides. It is, however, not as bad as it is now currently on the live site. It is an improvement. I will ask for assistance on this.
- Still need to do the dark screen option again as this was removed because it was completely broken.
- In zkEVM and PoS it would be good to remove the pages linked on menu headers sections and put them into a summary or overview page, or remove them completely if unnecessary for alignment across sections.