### PR TITLE
Adding git contributors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -637,6 +637,10 @@ plugins:
       strict: false
       exclude:
         - index.md
+  - git-authors:
+      show_contribution: true
+      exclude:
+        - index.md
 
 validation:
   absolute_links: ignore

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,5 +1,17 @@
 {% extends "base.html" %}
 
+{% block content %}
+  {{ super() }}
+
+  {% if git_page_authors %}
+    <div class="md-source-date">
+      <small>
+          Authors: {{ git_page_authors | default('enable mkdocs-git-authors-plugin') }}
+      </small>
+    </div>
+  {% endif %}
+{% endblock %}
+
 {% block scripts %}
   {{ super() }}
   

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs-material==9.5.1
 markdown-include==0.8.1
 mkdocs-git-revision-date-localized-plugin==1.2.1
 mkdocs-open-in-new-tab==1.0.3
+mkdocs-git-authors-plugin==0.7.2


### PR DESCRIPTION
Devops says they could not fix the issue with losing data between environments, so I'm trying again with a different plugin. Let's see if this works. 

Locally, it's pretty good:

![Screenshot 2024-01-08 at 11 44 30](https://github.com/0xPolygon/polygon-docs/assets/149679879/a1ccfd35-8aea-4543-bc7d-92a66ac4b681)
