### PR TITLE
Downgrading material version

### DIFF
--- a/.github/workflows/staging_deployment.yml
+++ b/.github/workflows/staging_deployment.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Use Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: pip Install
         run: pip install -r requirements.txt --no-cache-dir

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.5.1
+mkdocs-material==9.4.8
 markdown-include==0.8.1
 mkdocs-git-revision-date-localized-plugin==1.2.1
 mkdocs-open-in-new-tab==1.0.3


### PR DESCRIPTION
There is a dependency mismatch in environments.

This PR goes along with a python bump in the actions. 

Hopefully it will fix the plugin issues.