### PR TITLE
DO NOT MERGE: Move type 1 prover docs to LEARN section

### DIFF
--- a/docs/cdk/architecture/type-1-prover/intro-t1-prover.md
+++ b/docs/cdk/architecture/type-1-prover/intro-t1-prover.md
@@ -1,5 +1,8 @@
 The Polygon Type 1 Prover is a zk-evm proving component used for creating proofs on your ZK-EVM chain. It has been developed in collaboration with the Toposware team.
 
+!!! info
+    The Polygon Type 1 Prover is not yet ready for full implementation into a CDK stack.
+
 ## Get started
 
 If you want to get up and running quickly, follow the [how to deploy the Type 1 Prover guide](../../how-to/deploy-t1-prover.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,18 +81,8 @@ nav:
               - Start services: cdk/get-started/deploy-rollup/start-services.md
         - Connect to CDK testnet: cdk/get-started/connect-testnet.md
       - How to:
-        - Run Type 1 Prover quickly: cdk/how-to/deploy-t1-prover.md
-        - Deploy Type 1 Prover on devnet: cdk/how-to/deploy-t1-prover-devnet.md
         - Manage allowlists with policies: cdk/how-to/manage-policies.md
       - Architecture:
-        - Polygon Type 1 Prover:
-          - Introduction and definitions: cdk/architecture/type-1-prover/intro-t1-prover.md
-          - Type 1 design challenges: cdk/architecture/type-1-prover/t1-design-challenge.md
-          - Architectural overview: cdk/architecture/type-1-prover/t1-architecture.md
-          - Tests and proving costs: cdk/architecture/type-1-prover/testing-and-proving-costs.md
-          - CPU component: cdk/architecture/type-1-prover/t1-cpu-component.md
-          - CTL protocol: cdk/architecture/type-1-prover/t1-ctl-protocol.md
-          - Range checks: cdk/architecture/type-1-prover/t1-rangechecks.md
         - DAC: cdk/architecture/dac.md
       - Specification:
         - Validium vs rollup: cdk/spec/validium-vs-rollup.md
@@ -573,6 +563,19 @@ nav:
       - Learn: learn/index.md
       - Welcome: learn/welcome.md
       - Polygon AggLayer: learn/agglayer.md
+      - Polygon Type 1 Prover:
+          - Introduction and definitions: cdk/architecture/type-1-prover/intro-t1-prover.md
+          - How to:
+              - Run Type 1 Prover quickly: cdk/how-to/deploy-t1-prover.md
+              - Deploy Type 1 Prover on devnet: cdk/how-to/deploy-t1-prover-devnet.md
+          - Architecture:
+              - Overview: cdk/architecture/type-1-prover/t1-architecture.md
+              - Type 1 design challenges: cdk/architecture/type-1-prover/t1-design-challenge.md
+              - Tests and proving costs: cdk/architecture/type-1-prover/testing-and-proving-costs.md
+          - Specification:
+              - CPU component: cdk/architecture/type-1-prover/t1-cpu-component.md
+              - CTL protocol: cdk/architecture/type-1-prover/t1-ctl-protocol.md
+              - Range checks: cdk/architecture/type-1-prover/t1-rangechecks.md
       - Polygon protocols: learn/polygon-protocols.md
       - Polygon 2.0 architecture: learn/deep-dive-arch.md
 


### PR DESCRIPTION
This PR moves the Type 1 prover docs to the Learn section without affecting any URLs.