### PR TITLE
Update using-hardhat.md

### DIFF
--- a/docs/zkEVM/how-to/using-hardhat.md
+++ b/docs/zkEVM/how-to/using-hardhat.md
@@ -62,7 +62,7 @@ Next is the initialization of a project using Hardhat. Hardhat cannot initialize
 mv README.md README-tutorial.md
 ```
 
-- Initialize a project with Hardhat: ```npx hardhat```.
+- Initialize a project with Hardhat: ```npx hardhat init```.
 
 - Next, (... *To avoid failure ... please go slow with this cli dialogue*...),
 


### PR DESCRIPTION
I just updated the command for "initialize a project with Hardhat".
Because the ``npx hardhat`` command is no longer used to start a project. Instead, the ``npx hardhat init`` command is used.

Old version: ``npx hardhat``
New version: ``npx hardhat init``

Check this: https://hardhat.org/hardhat-runner/docs/getting-started