### PR TITLE
Remove author plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -672,16 +672,6 @@ plugins:
       strict: false
       exclude:
         - index.md
-  - git-authors:
-      show_contribution: true
-      exclude:
-        - index.md
-        - cdk/index.md
-        - zkEVM/index.md
-        - pos/index.md
-        - miden/index.md
-        - tools/index.md
-        - learn/index.md
 
 validation:
   absolute_links: ignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ mkdocs-material==9.4.8
 markdown-include==0.8.1
 mkdocs-git-revision-date-localized-plugin==1.2.1
 mkdocs-open-in-new-tab==1.0.3
-mkdocs-git-authors-plugin==0.7.2


### PR DESCRIPTION
Removing the author plugin for two reasons:

- It conflicts with the import plugin currently.
- It makes working on local extremely slow.