### PR TITLE
Include the Miden client docs as an import

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -338,6 +338,7 @@ nav:
   - Miden:
       - Miden: miden/index.md
       - Miden base: '!import https://github.com/0xPolygonMiden/miden-base?branch=main'
+      - Miden client: '!import https://github.com/0xPolygonMiden/miden-client?branch=main'
   - Developer tools: 
       - Developer tools: tools/index.md
       - dApp development: 


### PR DESCRIPTION
Small addition to mkdocs which imports the Miden client docs.

I have tested this and it works so just need an OK.