### PR TITLE
Dev tools, zkEVM: migrating how-tos

### DIFF
--- a/docs/tools/dApp-development/third-party-tutorials.md
+++ b/docs/tools/dApp-development/third-party-tutorials.md
@@ -20,7 +20,7 @@ Explore the categories below to discover third-party resources and tutorials to 
 
 ## Chain data and analytics services
 
-- OKLink
+- OKX explorer
     - [Verify contract with API](https://www.oklink.com/docs/en#on-chain-tools-contract-verification)
     - [Verify contract with external plugins](https://www.oklink.com/docs/en/#on-chain-tools-contract-verification-plugins)
 

--- a/docs/tools/dApp-development/third-party-tutorials.md
+++ b/docs/tools/dApp-development/third-party-tutorials.md
@@ -1,0 +1,32 @@
+!!! warning "Content disclaimer"
+    Please view the third-party content disclaimer [here](https://github.com/0xPolygon/polygon-docs/blob/main/CONTENT_DISCLAIMER.md).
+
+Explore the categories below to discover third-party resources and tutorials to support your journey in developing, deploying, and managing dApps in the Polygon ecosystem.
+
+## Node and infra providers
+
+- [Alchemy](https://www.alchemy.com/dapps/polygon-smart-contract-template)
+- [ChainStack](https://docs.chainstack.com/docs/polygon-tooling)
+- [GetBlock PoS](https://getblock.io/nodes/matic/)
+- [GetBlock zkEVM](https://getblock.io/nodes/polygon-zkevm/)
+- [QuickNode PoS](https://www.quicknode.com/docs/polygon)
+- [QuickNode zkEVM](https://www.quicknode.com/docs/polygon-zkevm)
+
+## Dev tools and platforms
+
+- [ChainIDE](https://chainide.gitbook.io/chainide-english-1/ethereum-ide-1/6.-polygon-ide)
+- [EthCreator](https://www.ethcreator.com/)
+- [Thirdweb](https://portal.thirdweb.com/contracts)
+
+## Chain data and analytics services
+
+- OKLink
+    - [Verify contract with API](https://www.oklink.com/docs/en#on-chain-tools-contract-verification)
+    - [Verify contract with external plugins](https://www.oklink.com/docs/en/#on-chain-tools-contract-verification-plugins)
+
+## Minting and payment solutions
+
+- Venly
+    - [NFT API](https://docs.venly.io/docs/nft-api-getting-started)
+    - [Zapier integration](https://docs.venly.io/docs/zapier-integration)
+- [Crossmint](https://blog.crossmint.com/how-to-create-and-mint-nfts-on-polygon/)

--- a/docs/zkEVM/how-to/index.md
+++ b/docs/zkEVM/how-to/index.md
@@ -1,3 +1,0 @@
-The aim with this section is to demonstrate that existing smart contracts, developer toolings and wallets work seamlessly in Polygon zkEVM as in Ethereum.
-
-Herein are guides to; writing a smart contract using the OpenZeppelin Wizard, deploying an NFT using Foundry, deploying an ERC-20 token using Hardhat, and verifying a smart contract either manually on the Explorer or using Remix.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -270,6 +270,7 @@ nav:
         - EVM vs. zkEVM: zkEVM/spec/evm-differences.md
       - API: 
         - JSON RPC endpoints: zkEVM/api/json-rpc.md
+        - Check transaction status: zkEVM/how-to/check-tx-status.md
       - Concepts:
         - Concepts: zkEVM/concepts/index.md
         - EVM basics: zkEVM/concepts/evm-basics.md
@@ -413,14 +414,14 @@ nav:
               - Deploy a contract with Foundry: zkEVM/how-to/using-foundry.md
               - Deploy a contract with Hardhat: zkEVM/how-to/using-hardhat.md
               - Verify a contract: zkEVM/how-to/verify-contract.md
-              - Check transaction status: zkEVM/how-to/check-tx-status.md
           - Third-party tutorials: tools/dApp-development/third-party-tutorials.md
-        #- OKLink:
-          #- OKLink verify contract with API: https://www.oklink.com/docs/en/#on-chain-tools-contract-verification 
-          #- OKLink verify contract with external plugins: https://www.oklink.com/docs/en/#on-chain-tools-contract-verification-plugins
-        #- Venly:
-          #- Venly's NFT-API: https://docs.venly.io/docs/nft-api-getting-started
-          #- Venly's Zapier integration: https://docs.venly.io/docs/zapier-integration
+      - Popular tools:
+        - OKX explorer:
+          - Verify contract with API: https://www.oklink.com/docs/en/#on-chain-tools-contract-verification 
+          - Verify contract with external plugins: https://www.oklink.com/docs/en/#on-chain-tools-contract-verification-plugins
+        - Venly:
+          - NFT-API: https://docs.venly.io/docs/nft-api-getting-started
+          - Zapier integration: https://docs.venly.io/docs/zapier-integration
       - Chain indexer framework:
           - Overview: tools/chain-indexer-framework/overview.md
           - Usage: tools/chain-indexer-framework/usage.md 
@@ -610,7 +611,7 @@ markdown_extensions:
   - footnotes
   - def_list
   - attr_list
-  - md_in_html
+  #- md_in_html
   - abbr
   - pymdownx.tabbed
   - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -420,7 +420,7 @@ nav:
           - Verify contract with API: https://www.oklink.com/docs/en/#on-chain-tools-contract-verification 
           - Verify contract with external plugins: https://www.oklink.com/docs/en/#on-chain-tools-contract-verification-plugins
         - Venly:
-          - NFT-API: https://docs.venly.io/docs/nft-api-getting-started
+          - NFT API: https://docs.venly.io/docs/nft-api-getting-started
           - Zapier integration: https://docs.venly.io/docs/zapier-integration
       - Chain indexer framework:
           - Overview: tools/chain-indexer-framework/overview.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,13 +87,6 @@ nav:
               - Start services: zkEVM/get-started/setup-nodes/deploy-zkevm/start-services.md
           - Sync state with snapshots: zkEVM/get-started/state-sync-snapshots.md
         - Historical data: zkEVM/get-started/historical-data.md
-      - How to:
-        - How to: zkEVM/how-to/index.md
-        - Write a contract: zkEVM/how-to/write-contract.md
-        - Deploy a contract with Foundry: zkEVM/how-to/using-foundry.md
-        - Deploy a contract with Hardhat: zkEVM/how-to/using-hardhat.md
-        - Verify a contract: zkEVM/how-to/verify-contract.md
-        - Check transaction status: zkEVM/how-to/check-tx-status.md
       - Architecture high-level:
         - Overview: zkEVM/architecture/high-level/overview.md
         - Smart contracts: 
@@ -410,20 +403,27 @@ nav:
               - Commands: tools/dApp-development/launchpad/commands.md
               - Contributing: tools/dApp-development/launchpad/contributing.md
               - Common pitfalls: tools/dApp-development/launchpad/common-pitfalls.md
-          - Common tools:
+          - Smart contract development:
+            - PoS:
               - Hardhat: tools/dApp-development/common-tools/hardhat.md
               - Remix: tools/dApp-development/common-tools/remix.md
               - Replit: tools/dApp-development/common-tools/replit.md
-          - Smart contract development: 
-              - Third-party tools: tools/dApp-development/pos/third-party-smart-contracts.md
+            - zkEVM:
+              - Write a contract: zkEVM/how-to/write-contract.md
+              - Deploy a contract with Foundry: zkEVM/how-to/using-foundry.md
+              - Deploy a contract with Hardhat: zkEVM/how-to/using-hardhat.md
+              - Verify a contract: zkEVM/how-to/verify-contract.md
+              - Check transaction status: zkEVM/how-to/check-tx-status.md
+          - Third-party tutorials: tools/dApp-development/third-party-tutorials.md
+        #- OKLink:
+          #- OKLink verify contract with API: https://www.oklink.com/docs/en/#on-chain-tools-contract-verification 
+          #- OKLink verify contract with external plugins: https://www.oklink.com/docs/en/#on-chain-tools-contract-verification-plugins
+        #- Venly:
+          #- Venly's NFT-API: https://docs.venly.io/docs/nft-api-getting-started
+          #- Venly's Zapier integration: https://docs.venly.io/docs/zapier-integration
       - Chain indexer framework:
           - Overview: tools/chain-indexer-framework/overview.md
-          - Usage: tools/chain-indexer-framework/usage.md
-      - Third-party tutorials:
-          - OKLink verify contract with API: https://www.oklink.com/docs/en/#on-chain-tools-contract-verification 
-          - OKLink verify contract with external plugins: https://www.oklink.com/docs/en/#on-chain-tools-contract-verification-plugins 
-          - Venly's NFT-API: https://docs.venly.io/docs/nft-api-getting-started
-          - Venly's Zapier integration: https://docs.venly.io/docs/zapier-integration 
+          - Usage: tools/chain-indexer-framework/usage.md 
       - Gas:
           - Polygon MATIC faucet: tools/gas/matic-faucet.md
           - Polygon gas station: tools/gas/polygon-gas-station.md
@@ -610,6 +610,7 @@ markdown_extensions:
   - footnotes
   - def_list
   - attr_list
+  - md_in_html
   - abbr
   - pymdownx.tabbed
   - pymdownx.superfences


### PR DESCRIPTION
- Consolidate third-party tutorials in dev tools space
- In-house smart contract dev tutorials classified into PoS and zkEVM
- Add zkEVM 'how-to' tutorials to the zkEVM category
- Modify mkdocs.yml to delete 'how-to' section from zkEVM space
- Files continue to live in the zkEVM directory (to avoid 404s)