### PR TITLE
I&D, CDK: remove polygon 2.0

### DIFF
--- a/docs/cdk/glossary/index.md
+++ b/docs/cdk/glossary/index.md
@@ -5,7 +5,7 @@ comments: true
 This glossary provides definitions for technical terminology and concepts that commonly occur throughout the CDK docs space.
 
 ### AggLayer v1 (AL1)
-The AggLayer is the interoperability layer at the heart of Polygon 2.0. All CDK chains connect to the AggLayer to enable features such as seamless and efficient cross-chain communication, unified liquidity, and more. AggLayer v1 (AL1), is the first version of many planned iterations that relies on ZK checks to ensure operational soundness, and a unified bridge infrastructure.
+The AggLayer is the interoperability layer that CDK chains connect to, enabling features such as seamless and efficient cross-chain communication, unified liquidity, and more. AggLayer v1 (AL1), is the first version of many planned iterations that relies on ZK checks to ensure operational soundness, and a unified bridge infrastructure.
 Read more on the AggLayer in the Polygon blog [here](https://polygon.technology/blog/wtf-is-polygon?utm_source=twitter&utm_medium=social&utm_content=wtf-is-polygon).
 
 ### Chain operator
@@ -24,7 +24,7 @@ The native bridge infrastructure of CDK chains that allows transfer of assets an
 A contract on the LxLy bridge utilizes its message passing capabilities to pass arbitrary messages between L1 and L2.  This is not a separate component, and is part of the LxLy bridge's architecture.
 
 ### POL (Token)
-The POL token powers the Polygon 2.0 ecosystem through a native re-staking protocol that allows token holders to validate multiple chains, and perform multiple roles on each of those chains (sequencing, ZK proof generation, participation in data availability committees, etc.) 
+The POL token powers the Polygon ecosystem through a native re-staking protocol that allows token holders to validate multiple chains, and perform multiple roles on each of those chains (sequencing, ZK proof generation, participation in data availability committees, etc.) 
 
 ### Rollups
 Rollups refer to blockchain scaling solutions (in the context of Ethereum) that carry out transaction execution on L2, and then post updated state data to a contract on L1. There are different types rollups, two of the most popular being optimistic, and zero-knowledge (ZK) rollups. Follow the links below to learn more:

--- a/docs/cdk/glossary/index.md
+++ b/docs/cdk/glossary/index.md
@@ -21,7 +21,7 @@ Polygon CDK validiums connect to a DAC to guarantee data availability. The DAC n
 The native bridge infrastructure of CDK chains that allows transfer of assets and messages between L2 and L1 (typically Ethereum).
 
 ### LxLy messenger
-A contract on the LxLy bridge utilizes its message passing capabilities to pass arbitrary messages between L1 and L2.  This is not a separate component, and is part of the LxLy bridge's architecture.
+A contract on the LxLy bridge utilizes its message passing capabilities to pass arbitrary messages between L1 and L2.  This is not a separate component, but part of the LxLy bridge's architecture.
 
 ### POL (Token)
 The POL token powers the Polygon ecosystem through a native re-staking protocol that allows token holders to validate multiple chains, and perform multiple roles on each of those chains (sequencing, ZK proof generation, participation in data availability committees, etc.) 

--- a/docs/innovation-design/index.md
+++ b/docs/innovation-design/index.md
@@ -26,7 +26,7 @@ hide:
       <h1 class="hero-heading">Innovation & design</h1>
       <p class="hero-subtext">The Polygon Knowledge Layer consists of technical documentation that developers need for building with Polygon protocols, products, and services.</p> 
       <p class="hero-subtext">We also publish resources necessary for learning about and contributing to Polygon technologies.</p>
-      <p class="hero-subtext">This section gives you a peek into the future, the community-driven Polygon 2.0 vision focussing on cutting-edge web3 development.
+      <p class="hero-subtext">This section gives you a peek into the future: a community-driven  vision centered on cutting-edge Web3 development.
       </p>
    </div>
 </div>
@@ -58,9 +58,9 @@ hide:
     <div class="grid-item">
       <a href="./polygon-protocols">
          <div class="product-list-item-header">
-            <div class="feature-card-heading">Polygon 2.0</div>
+            <div class="feature-card-heading">The future of Polygon network</div>
          </div>
-         <p class="feature-paragraph">Widely-adopted EVM-compatible sidechain designed for low transaction costs and fast transaction times.</p>
+         <p class="feature-paragraph">Upcoming updates and iterations across Polygon network</p>
       </a>
    </div>
    <div class="grid-item">

--- a/docs/innovation-design/polygon-protocols.md
+++ b/docs/innovation-design/polygon-protocols.md
@@ -42,7 +42,7 @@ EVM-equivalence: As EIPs change and shape Ethereum’s execution logic, Polygon 
 - EIP-4844: Expected in the Cancun hard fork, proto-Danksharding creates a low-cost alternative to CALLDATA, expected to greatly reduce transaction fees on rollups.
 - EIP-7212: A new precompiled contract will support signature verifications in the secp256r1 elliptic curve.
 
-Polygon zkEVM will continue to offer the strongest open source software security guarantees by making transaction data available (DA) on Ethereum. Eventually, Polygon zkEVM will plug into the unified interop layer that will help connect the entire Polygon ecosystem.
+Polygon zkEVM will continue to offer the strongest open source software security guarantees by making transaction data available (DA) on Ethereum. Eventually, Polygon zkEVM will plug into the Agglayer that will help connect the entire Polygon ecosystem.
 
 ## Polygon CDK
 
@@ -52,7 +52,7 @@ Polygon CDK is a collection of open source software components for launching ZK-
 
 The next release of Polygon CDK, expected in Q1 2024, will support a wider set of features and configurations. These include:
 
-- The unified LxLy bridge: As the first phase of the interop layer, projects building with CDK will have the option to plug into the unified LxLy bridge that will, eventually, help connect the entire Polygon ecosystem.
+- The unified LxLy bridge: As the first phase of the Agglayer development, projects building with CDK will have the option to plug into the unified LxLy bridge that will, eventually, help connect the entire Polygon ecosystem.
 - Custom native (gas) tokens.
 - Custom allow-lists for smart contracts and transactions.
 - Support for modular, third-party data availability solutions.
@@ -63,6 +63,6 @@ Polygon Miden is a novel ZK rollup currently in development, designed as a zkVM.
 
 ### Where Polygon Miden is heading
 
-A testnet for Polygon Miden is expected to launch in Q1 2024, with mainnet following later in the year. 
+The new version (v2) of Polygon Miden Alpha testnet was [launched in Q2 2024](https://polygon.technology/blog/polygon-miden-alpha-testnet-v-2-live), and the mainnet is expected to go live later in the year.
 
-Once Polygon Miden is on mainnet, it will plug into the interop layer that will help connect the entire Polygon ecosystem.
+Once Polygon Miden is on mainnet, it will plug into the Agglayer that will help connect the entire Polygon ecosystem.

--- a/docs/innovation-design/polygon-protocols.md
+++ b/docs/innovation-design/polygon-protocols.md
@@ -14,7 +14,10 @@ Here is how the proposed development, with consensus of the Polygon community, w
 - Changes to network token.
 - Introduction of a Staking Layer, which will eventually serve all L2 chains in the Polygon network.
 
-[PIP-18](https://forum.polygon.technology/t/pip-18-polygon-2-0-phase-0-frontier/12913) has suggested a phased approach for upgrading Polygon PoS to a zkEVM validium. This community discussion is guiding the technical specification of the potential upgrade. If this PIP is accepted, Polygon PoS will eventually plug into the interop layer that will connect the entire Polygon network. 
+[PIP-18](https://forum.polygon.technology/t/pip-18-polygon-2-0-phase-0-frontier/12913) has suggested a phased approach for upgrading Polygon PoS to a zkEVM validium. This community discussion is guiding the technical specification of the potential upgrade. If this PIP is accepted, Polygon PoS will eventually plug into the Agglayer that will connect the entire Polygon network.
+
+!!! info "What's Agglayer?"
+    AggLayer is the interoperability layer that EVM-compatible chains connect to, enabling features such as seamless and efficient cross-chain communication, unified liquidity, and more. Read more on the AggLayer in the [Polygon blog](https://polygon.technology/blog/wtf-is-polygon?utm_source=twitter&utm_medium=social&utm_content=wtf-is-polygon).
 
 Phase 0 of PIP-18 includes:
 

--- a/docs/innovation-design/polygon-protocols.md
+++ b/docs/innovation-design/polygon-protocols.md
@@ -14,7 +14,7 @@ Here is how the proposed development, with consensus of the Polygon community, w
 - Changes to network token.
 - Introduction of a Staking Layer, which will eventually serve all L2 chains in the Polygon network.
 
-PIP-18 has suggested a phased approach for upgrading Polygon PoS to a zkEVM validium. This community discussion is guiding the technical specification of the potential upgrade. If this PIP is accepted, Polygon PoS will eventually plug into the interop layer that will connect the entire Polygon network. 
+[PIP-18](https://forum.polygon.technology/t/pip-18-polygon-2-0-phase-0-frontier/12913) has suggested a phased approach for upgrading Polygon PoS to a zkEVM validium. This community discussion is guiding the technical specification of the potential upgrade. If this PIP is accepted, Polygon PoS will eventually plug into the interop layer that will connect the entire Polygon network. 
 
 Phase 0 of PIP-18 includes:
 

--- a/docs/innovation-design/polygon-protocols.md
+++ b/docs/innovation-design/polygon-protocols.md
@@ -14,9 +14,9 @@ Here is how the proposed development, with consensus of the Polygon community, w
 - Changes to network token.
 - Introduction of a Staking Layer, which will eventually serve all L2 chains in the Polygon network.
 
-Polygon 2.0: A pre-PIP discussion for upgrading Polygon PoS to a zkEVM validium is underway. This community discussion is guiding the technical specification of the potential upgrade. If this PIP is accepted, Polygon PoS will eventually plug into the interop layer that will connect the entire Polygon network. 
+PIP-18 has suggested a phased approach for upgrading Polygon PoS to a zkEVM validium. This community discussion is guiding the technical specification of the potential upgrade. If this PIP is accepted, Polygon PoS will eventually plug into the interop layer that will connect the entire Polygon network. 
 
-Phase 0: PIP-18 has suggested a phased approach to implementation of Polygon 2.0. As it relates to Polygon PoS, Phase 0 includes:
+Phase 0 of PIP-18 includes:
 
 - The initiation of the POL upgrade
 - The upgrade from MATIC to POL as the native (gas) token for PoS
@@ -39,7 +39,7 @@ EVM-equivalence: As EIPs change and shape Ethereum’s execution logic, Polygon 
 - EIP-4844: Expected in the Cancun hard fork, proto-Danksharding creates a low-cost alternative to CALLDATA, expected to greatly reduce transaction fees on rollups.
 - EIP-7212: A new precompiled contract will support signature verifications in the secp256r1 elliptic curve.
 
-Polygon 2.0: Polygon zkEVM will continue to offer the strongest open source software security guarantees by making transaction data available (DA) on Ethereum. Eventually, Polygon zkEVM will plug into the unified interop layer that will help connect the entire Polygon ecosystem.
+Polygon zkEVM will continue to offer the strongest open source software security guarantees by making transaction data available (DA) on Ethereum. Eventually, Polygon zkEVM will plug into the unified interop layer that will help connect the entire Polygon ecosystem.
 
 ## Polygon CDK
 
@@ -47,7 +47,7 @@ Polygon CDK is a collection of open source software components for launching ZK-
 
 ### Where Polygon CDK is heading
 
-Upcoming release: The next release of Polygon CDK, expected in Q1 2024, will support a wider set of features and configurations. These include:
+The next release of Polygon CDK, expected in Q1 2024, will support a wider set of features and configurations. These include:
 
 - The unified LxLy bridge: As the first phase of the interop layer, projects building with CDK will have the option to plug into the unified LxLy bridge that will, eventually, help connect the entire Polygon ecosystem.
 - Custom native (gas) tokens.
@@ -56,10 +56,10 @@ Upcoming release: The next release of Polygon CDK, expected in Q1 2024, will sup
 
 ## Polygon Miden
 
-Polygon Miden is an in-development, novel ZK rollup designed as a zkVM. Powered by the Miden VM, Polygon Miden extends Ethereum’s feature set, providing throughput and privacy features that are beyond the capabilities of the EVM. 
+Polygon Miden is a novel ZK rollup currently in development, designed as a zkVM. Powered by the Miden VM, Polygon Miden extends Ethereum’s capabilities, offering enhanced throughput and privacy features beyond those of the EVM.
 
 ### Where Polygon Miden is heading
 
 A testnet for Polygon Miden is expected to launch in Q1 2024, with mainnet following later in the year. 
 
-Polygon 2.0: Once Polygon Miden is on mainnet, it will plug into the interop layer that will help connect the entire Polygon ecosystem.
+Once Polygon Miden is on mainnet, it will plug into the interop layer that will help connect the entire Polygon ecosystem.

--- a/docs/innovation-design/polygon-protocols.md
+++ b/docs/innovation-design/polygon-protocols.md
@@ -39,8 +39,9 @@ Security: The two near-term priorities for Polygon zkEVM are:
 - Lengthening the 10-day timelock for network upgrades.
 
 EVM-equivalence: As EIPs change and shape Ethereum’s execution logic, Polygon zkEVM will evolve to maintain EVM-equivalence. The two most important forthcoming changes are:
-- EIP-4844: Expected in the Cancun hard fork, proto-Danksharding creates a low-cost alternative to CALLDATA, expected to greatly reduce transaction fees on rollups.
-- EIP-7212: A new precompiled contract will support signature verifications in the secp256r1 elliptic curve.
+
+- [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844): Expected in the Cancun hard fork, proto-Danksharding creates a low-cost alternative to CALLDATA, expected to greatly reduce transaction fees on rollups.
+- [EIP-7212](https://eips.ethereum.org/EIPS/eip-7212): A new precompiled contract will support signature verifications in the secp256r1 elliptic curve.
 
 Polygon zkEVM will continue to offer the strongest open source software security guarantees by making transaction data available (DA) on Ethereum. Eventually, Polygon zkEVM will plug into the Agglayer that will help connect the entire Polygon ecosystem.
 

--- a/docs/innovation-design/welcome.md
+++ b/docs/innovation-design/welcome.md
@@ -20,5 +20,5 @@ Fundamentally, building this web of ZK-powered L2s comes down to one challenge: 
 
 The best way to accomplish this goal is through zero-knowledge cryptography as it is capable of providing verifiable proofs that attest to the integrity of off-chain computations. Otherwise, scaling technologies often have to add additional socio-economic mechanisms to mediate off-chain computations, which often results in delayed settlement of transactions.
 
-Future iterations will focus on applying the open source, zero-knowledge scaling technology developed at Polygon Labs, and this will allow Ethereum to scale to the limits of the internet.
+Future iterations will focus on applying the open source, zero-knowledge scaling technology developed at Polygon Labs, and these advancements will enable Ethereum to scale to the limits of the internet..
 

--- a/docs/innovation-design/welcome.md
+++ b/docs/innovation-design/welcome.md
@@ -10,7 +10,7 @@ This section offers a glimpse into the future, presenting a vision that is commu
 
 Polygon technologies will help developers build in an elastically scalable and *unified* ecosystem of ZK-powered Layer 2s on Ethereum, where users can create, program and exchange value.
 
-Polygon envisions a unified multichain ecosystem. A web of interoperable ZK-powered Ethereum L2s, with near-instant and atomic L2 <-> L2 transactions, and designed to empower developers to build without limitations. Developers will choose to build dApps, design and launch dedicated application-specific L2 chains, or migrate existing EVM Layer 1 chains to become an L2.
+Polygon envisions a unified multichain ecosystem. A web of interoperable ZK-powered Ethereum L2s, with near-instant and atomic L2 <-> L2 transactions, designed to empower developers build without limitations. An ecosystem where developers can choose to build dApps, design and launch dedicated application-specific L2 chains, or migrate existing EVM Layer 1 chains to become L2s.
 
 The endgame is to allow developers to build in an environment that feels and functions more like the internet. This means a blockchain ecosystem that can scale without limit, seamlessly unified, and backed by the decentralization and security of Ethereum.
 

--- a/docs/innovation-design/welcome.md
+++ b/docs/innovation-design/welcome.md
@@ -4,21 +4,21 @@ comments: true
 
 The Polygon Knowledge Layer consists of two parts. Firstly, documents that developers need in order to build with Polygon protocols. Secondly, resources necessary for learning about Polygon technologies.
 
-The Learn section gives you a peek into the future, the Polygon 2.0 vision which is community-driven.
+This section offers a glimpse into the future, presenting a vision that is community-driven.
 
-## Polygon 2.0: The basics
+## The basics
 
-Polygon technologies will help developers build in an elastically scalable and unified ecosystem of ZK-powered Layer 2s on Ethereum, where users can create, program and exchange value.
+Polygon technologies will help developers build in an elastically scalable and *unified* ecosystem of ZK-powered Layer 2s on Ethereum, where users can create, program and exchange value.
 
-The Polygon 2.0 vision is a unified multichain ecosystem. A web of interoperable ZK-powered Ethereum L2s, with near-instant and atomic L2 <> L2 transactions, and designed to empower developers to build without limitations. Developers will choose to build dApps, design and launch dedicated application-specific L2 chains, or migrate existing EVM Layer 1 chains to become an L2.
+Polygon envisions a unified multichain ecosystem. A web of interoperable ZK-powered Ethereum L2s, with near-instant and atomic L2 <-> L2 transactions, and designed to empower developers to build without limitations. Developers will choose to build dApps, design and launch dedicated application-specific L2 chains, or migrate existing EVM Layer 1 chains to become an L2.
 
-The endgame of Polygon 2.0 is for developers to build in an environment that feels and functions more like the internet. This means a blockchain ecosystem that can scale without limit, seamlessly unified, and backed by the decentralization and security of Ethereum.
+The endgame is to allow developers to build in an environment that feels and functions more like the internet. This means a blockchain ecosystem that can scale without limit, seamlessly unified, and backed by the decentralization and security of Ethereum.
 
 ### Zero-knowledge is the key
 
-Fundamentally, building this web of ZK-powered L2s comes down to one challenge: trustless, off-chain computation. In order to scale Ethereum, one needs to preserve Ethereum’s execution logic while making it more efficient. 
+Fundamentally, building this web of ZK-powered L2s comes down to one challenge: trustless, off-chain computation. In order to scale Ethereum, one needs to preserve Ethereum’s execution logic while making it more efficient.
 
-The best way to accomplish this goal is through zero-knowledge cryptography as it is capable of providing verifiable proofs that attest to the integrity of off-chain computations. Otherwise, scaling technologies often have to add additional social-economic mechanisms to mediate off-chain computations. The consequence of which is delayed settlement of transactions.
+The best way to accomplish this goal is through zero-knowledge cryptography as it is capable of providing verifiable proofs that attest to the integrity of off-chain computations. Otherwise, scaling technologies often have to add additional socio-economic mechanisms to mediate off-chain computations, which often results in delayed settlement of transactions.
 
-Polygon 2.0 applies the open source, zero-knowledge scaling technology developed at Polygon Labs, and this will allow Ethereum to scale to the limits of the internet.
+Future iterations will focus on applying the open source, zero-knowledge scaling technology developed at Polygon Labs, and this will allow Ethereum to scale to the limits of the internet.
 


### PR DESCRIPTION
This PR covers:

- Remove references to Polygon 2.0 to avoid confusion.
- Change "Interop layer" -> "Agglayer"
- Add EIP links
- Miden testnet update
- Other minor fixes