### PR TITLE
Update rpc-endpoints.md

### DIFF
--- a/docs/pos/reference/rpc-endpoints.md
+++ b/docs/pos/reference/rpc-endpoints.md
@@ -117,5 +117,6 @@ Public RPCs may have rate limits or traffic restrictions. For dedicated free RPC
 - [4EVERLAND](https://docs.4everland.org/rpc-beta/polygon)
 - [SubQuery](https://subquery.network/rpc)
 - [Validation Cloud](https://app.validationcloud.io)
+- [dRPC](https://drpc.org/chainlist/polygon)
 
 For a complete list of public endpoints, visit [Alchemy's Chain Connect](https://www.alchemy.com/chain-connect/chain/polygon-pos) and [Chainlist](https://chainlist.org/?search=Polygon+Mainnet).


### PR DESCRIPTION
Added dRPC's public RPC t end of the list. dRPC's endpoints are used by Lido, Curve and Sushi so it deserves its place on the list.