### PR TITLE
Plaform: Missing tag on robots.txt file

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-https://docs.polygon.technology/sitemap.xml
+Sitemap: https://docs.polygon.technology/sitemap.xml


### PR DESCRIPTION
robots.txt file missing a Sitemap: tag.