### PR TITLE
DO NOT MERGE: ISSUES NOT PR: Update the script start command in checking ENV in CDK Getting Started

### DIFF
--- a/docs/cdk/getting-started/index.md
+++ b/docs/cdk/getting-started/index.md
@@ -34,10 +34,10 @@ cd kurtosis-cdk
 
 ### Checking your environment
 
-Ensure Docker is running on your machine, then run the following command to confirm that all prerequisites are installed:
+Ensure Docker is running on your machine, then run the following command to confirm that all prerequisites are installed, run the tool_check.sh script. You may need to make the script executable: chmod +x scripts/tool_check.sh
 
 ```bash
-sh scripts/tool_check.sh
+./scripts/tool_check.sh
 ```
 
 If everything is installed correctly, you should see the following output:

--- a/docs/cdk/getting-started/index.md
+++ b/docs/cdk/getting-started/index.md
@@ -146,7 +146,7 @@ Let&rsquo;s perform some basic read and write operations on the L2 using Foundry
 Export the RPC URL of your L2 to an environment variable called `ETH_RPC_URL` with the following command:
 
 ```bash
-export ETH_RPC_URL="$(kurtosis port print cdk-v1 zkevm-node-rpc-001 http-rpc)"
+export ETH_RPC_URL="$(kurtosis port print cdk-v1 cdk-erigon-node-001 http-rpc)"
 ```
 
 Then, use `cast` to view information about the chain, such as the latest block number:

--- a/docs/cdk/getting-started/index.md
+++ b/docs/cdk/getting-started/index.md
@@ -34,7 +34,7 @@ cd kurtosis-cdk
 
 ### Checking your environment
 
-Ensure Docker is running on your machine, then run the following command to confirm that all prerequisites are installed, run the tool_check.sh script. You may need to make the script executable: chmod +x scripts/tool_check.sh
+Ensure Docker is running on your machine, then run the tool_check.sh script to confirm that all prerequisites are installed. You may need to make the script executable: chmod +x scripts/tool_check.sh
 
 ```bash
 ./scripts/tool_check.sh


### PR DESCRIPTION
Changed the script call method from sh to ./ for

1. Fixes problems - who has basic SHELL - bash
example:
```bash
xxx@node:~/kurtosis-cdk$ sh scripts/tool_check.sh
Checking that you have the necessary tools to deploy the Kurtosis CDK package...
❌ kurtosis is not installed. Please install kurtosis to proceed: https://docs.kurtosis.com/install/
/usr/bin/kurtosis

xxx@node:~/kurtosis-cdk$ ./scripts/tool_check.sh
Checking that you have the necessary tools to deploy the Kurtosis CDK package...
✅ kurtosis 1.0.0 is installed, meets the requirement (=1.0).
✅ docker 27.1.1 is installed, meets the requirement (>=24.7).
...
🎉 You are ready to go!
```
 
2. To unify the approach of running scripts 
example of the approach used in the Readme - https://github.com/0xPolygon/polygon-docs/blob/main/README.md 
