### PR TITLE
Automate dev builds

### DIFF
--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: ['dev']
   workflow_dispatch:
+  schedule:
+    - cron: '*/30 * * * *'
 
 jobs:
   deploy_staging:
@@ -23,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ref: dev
           submodules: true
 
       - name: Configure AWS credentials


### PR DESCRIPTION
I would like the build to auto-run every 30 minutes to accommodate DevRel Learn writing flow, and to allow us to keep pushing content no matter timezone / availability. We will leave prod pushes as manual.