### PR TITLE
Add run number to image tag

### DIFF
--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -54,7 +54,7 @@ jobs:
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: ${{ github.sha }}-${{ github.run_number }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f .github/assets/Dockerfile.nginx .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
This prevents image conflicts. When a github commit is put onto AWS, it uses the commit as hash of the image. If nothing has changed, then it will fail because the ECR is immutable and cannot have images overwriting. So we need to change the image tag to be different on every run, in this case, we append the run number. Should be fine.