### PR TITLE
Platform: Removing dev scheduling (for now at least)

### DIFF
--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -1,7 +1,7 @@
 name: Docs Dev Deployment
 on:
-  schedule:
-    - cron: '0 */12 * * *'    
+  #schedule:
+  #  - cron: '0 */12 * * *'    
   push:
     branches: ['dev']
   pull_request:


### PR DESCRIPTION
- The scheduling is in the way of the other triggers so the environment doesn't build on a push or PR.
- Just commenting it out while we don't need it but can add back when necessary.