### PR TITLE
Fix for taskdef template after datadog integration enabled

### DIFF
--- a/.github/assets/polygon-docs-dev-taskdef.json
+++ b/.github/assets/polygon-docs-dev-taskdef.json
@@ -9,8 +9,19 @@
 		"logConfiguration": {
                 "logDriver": "awsfirelens",
                 "options": {
-                    "Name": "OpenTelemetry"
-                }
+                    "Name": "datadog",
+                    "Host": "http-intake.logs.datadoghq.com",
+                    "dd_service": "polygon-docs-dev",
+                    "dd_source": "nodejs",
+                    "TLS": "on",
+                    "provider": "ecs"
+                },
+                "secretOptions": [
+                    {
+                        "name": "apiKey",
+                        "valueFrom": "arn:aws:ssm:eu-west-1:058264511034:parameter/DATADOG_APIKEY"
+                    }
+                ]
             },
 		"entryPoint": null,
 		"portMappings": [{
@@ -55,67 +66,37 @@
 			"credentialsParameter": ""
 		}
 	},
-		{
-			"essential": false,
-            "name": "otel-collector",
-            "image": "otel/opentelemetry-collector-contrib",
-            "firelensConfiguration": {
-                "type": "fluentbit",
-                "options": {}
-            },
-            "portMappings": [
-                {
-                    "name": "otel-collector-4317-tcp",
-                    "containerPort": 4317,
-                    "hostPort": 4317,
-                    "protocol": "tcp",
-                    "appProtocol": "grpc"
-                },
-                {
-                    "name": "otel-collector-4318-tcp",
-                    "containerPort": 4318,
-                    "hostPort": 4318,
-                    "protocol": "tcp",
-                    "appProtocol": "grpc"
-                }
-            ],
-            "command": [
-                "--config",
-                "env:SSM_CONFIG"
-            ],
-            "environment": [
-                {
-                    "name": "CORALOGIX_DOMAIN",
-                    "value": "eu2.coralogix.com"
-                }
-            ],
-            "secrets": [
-                {
-                    "name": "SSM_CONFIG",
-                    "valueFrom": "arn:aws:ssm:eu-west-1:058264511034:parameter/CORALOGIX/CX_OTEL/config.yaml"
-                },
-                {
-                    "name": "PRIVATE_KEY",
-                    "valueFrom": "arn:aws:ssm:eu-west-1:058264511034:parameter/CORALOGIX/PRIVATE_KEY"
-                }
-            ],
-            "user": "0",
-            "memoryReservation": 50,
-            "resourceRequirements": null,
-            "environmentFiles": [],
-            "mountPoints": null,
-            "volumesFrom": null,
-            "hostname": null,
-            "workingDirectory": null,
-            "extraHosts": null,
-            "logConfiguration": null,
-            "ulimits": null,
-            "dockerLabels": null,
-            "dependsOn": null,
-            "repositoryCredentials": {
-                "credentialsParameter": ""
-            }
-		}],
+	{
+		"essential": true,
+		"image": "amazon/aws-for-fluent-bit:stable",
+		"name": "log_router",
+		"firelensConfiguration": {
+			"type": "fluentbit",
+			"options": {
+				"enable-ecs-log-metadata": "true"
+			}
+		},
+		"environment": null,
+		"secrets": null,
+		"memoryReservation": 50,
+		"resourceRequirements": null,
+		"portMappings": [],
+		"environmentFiles": [],
+		"mountPoints": null,
+		"volumesFrom": null,
+		"hostname": null,
+		"user": null,
+		"workingDirectory": null,
+		"extraHosts": null,
+		"logConfiguration": null,
+		"ulimits": null,
+		"dockerLabels": null,
+		"dependsOn": null,
+		"repositoryCredentials": {
+			"credentialsParameter": ""
+			}
+		}
+	],
 	"volumes": [],
 	"networkMode": "awsvpc",
 	"memory": "1024",

--- a/.github/assets/polygon-docs-staging-taskdef.json
+++ b/.github/assets/polygon-docs-staging-taskdef.json
@@ -9,8 +9,19 @@
 		"logConfiguration": {
                 "logDriver": "awsfirelens",
                 "options": {
-                    "Name": "OpenTelemetry"
-                }
+                    "Name": "datadog",
+                    "Host": "http-intake.logs.datadoghq.com",
+                    "dd_service": "polygon-docs-staging",
+                    "dd_source": "nodejs",
+                    "TLS": "on",
+                    "provider": "ecs"
+                },
+                "secretOptions": [
+                    {
+                        "name": "apiKey",
+                        "valueFrom": "arn:aws:ssm:eu-west-1:070528468658:parameter/DATADOG_APIKEY"
+                    }
+                ]
             },
 		"entryPoint": null,
 		"portMappings": [{
@@ -56,56 +67,25 @@
 		}
 	},
 	{
-		"essential": false,
-		"name": "otel-collector",
-		"image": "otel/opentelemetry-collector-contrib",
+		"essential": true,
+		"image": "amazon/aws-for-fluent-bit:stable",
+		"name": "log_router",
 		"firelensConfiguration": {
 			"type": "fluentbit",
-			"options": {}
+			"options": {
+				"enable-ecs-log-metadata": "true"
+			}
 		},
-		"portMappings": [
-			{
-				"name": "otel-collector-4317-tcp",
-				"containerPort": 4317,
-				"hostPort": 4317,
-				"protocol": "tcp",
-				"appProtocol": "grpc"
-			},
-			{
-				"name": "otel-collector-4318-tcp",
-				"containerPort": 4318,
-				"hostPort": 4318,
-				"protocol": "tcp",
-				"appProtocol": "grpc"
-			}
-		],
-		"command": [
-			"--config",
-			"env:SSM_CONFIG"
-		],
-		"environment": [
-			{
-				"name": "CORALOGIX_DOMAIN",
-				"value": "eu2.coralogix.com"
-			}
-		],
-		"secrets": [
-			{
-				"name": "SSM_CONFIG",
-				"valueFrom": "arn:aws:ssm:eu-west-1:070528468658:parameter/CORALOGIX/CX_OTEL/config.yaml"
-			},
-			{
-				"name": "PRIVATE_KEY",
-				"valueFrom": "arn:aws:ssm:eu-west-1:070528468658:parameter/CORALOGIX/PRIVATE_KEY"
-			}
-		],
-		"user": "0",
+		"environment": null,
+		"secrets": null,
 		"memoryReservation": 50,
 		"resourceRequirements": null,
+		"portMappings": [],
 		"environmentFiles": [],
 		"mountPoints": null,
 		"volumesFrom": null,
 		"hostname": null,
+		"user": null,
 		"workingDirectory": null,
 		"extraHosts": null,
 		"logConfiguration": null,
@@ -114,8 +94,9 @@
 		"dependsOn": null,
 		"repositoryCredentials": {
 			"credentialsParameter": ""
+			}
 		}
-	}],
+	],
 	"volumes": [],
 	"networkMode": "awsvpc",
 	"memory": "512",

--- a/.github/assets/polygon-docs-taskdef.json
+++ b/.github/assets/polygon-docs-taskdef.json
@@ -9,8 +9,19 @@
 		"logConfiguration": {
                 "logDriver": "awsfirelens",
                 "options": {
-                    "Name": "OpenTelemetry"
-                }
+                    "Name": "datadog",
+                    "Host": "http-intake.logs.datadoghq.com",
+                    "dd_service": "polygon-docs",
+                    "dd_source": "nodejs",
+                    "TLS": "on",
+                    "provider": "ecs"
+                },
+                "secretOptions": [
+                    {
+                        "name": "apiKey",
+                        "valueFrom": "arn:aws:ssm:eu-west-1:042947190491:parameter/DATADOG_APIKEY"
+                    }
+                ]
             },
 		"entryPoint": null,
 		"portMappings": [{
@@ -56,56 +67,25 @@
 		}
 	},
 	{
-		"essential": false,
-		"name": "otel-collector",
-		"image": "otel/opentelemetry-collector-contrib",
+		"essential": true,
+		"image": "amazon/aws-for-fluent-bit:stable",
+		"name": "log_router",
 		"firelensConfiguration": {
 			"type": "fluentbit",
-			"options": {}
+			"options": {
+				"enable-ecs-log-metadata": "true"
+			}
 		},
-		"portMappings": [
-			{
-				"name": "otel-collector-4317-tcp",
-				"containerPort": 4317,
-				"hostPort": 4317,
-				"protocol": "tcp",
-				"appProtocol": "grpc"
-			},
-			{
-				"name": "otel-collector-4318-tcp",
-				"containerPort": 4318,
-				"hostPort": 4318,
-				"protocol": "tcp",
-				"appProtocol": "grpc"
-			}
-		],
-		"command": [
-			"--config",
-			"env:SSM_CONFIG"
-		],
-		"environment": [
-			{
-				"name": "CORALOGIX_DOMAIN",
-				"value": "eu2.coralogix.com"
-			}
-		],
-		"secrets": [
-			{
-				"name": "SSM_CONFIG",
-				"valueFrom": "arn:aws:ssm:eu-west-1:042947190491:parameter/CORALOGIX/CX_OTEL/config.yaml"
-			},
-			{
-				"name": "PRIVATE_KEY",
-				"valueFrom": "arn:aws:ssm:eu-west-1:042947190491:parameter/CORALOGIX/PRIVATE_KEY"
-			}
-		],
-		"user": "0",
+		"environment": null,
+		"secrets": null,
 		"memoryReservation": 50,
 		"resourceRequirements": null,
+		"portMappings": [],
 		"environmentFiles": [],
 		"mountPoints": null,
 		"volumesFrom": null,
 		"hostname": null,
+		"user": null,
 		"workingDirectory": null,
 		"extraHosts": null,
 		"logConfiguration": null,
@@ -114,8 +94,9 @@
 		"dependsOn": null,
 		"repositoryCredentials": {
 			"credentialsParameter": ""
+			}
 		}
-	}],
+	],
 	"volumes": [],
 	"networkMode": "awsvpc",
 	"memory": "1024",


### PR DESCRIPTION
Hosted url: [docs-dev.polygon.technology/2456](https://docs-dev.polygon.technology/2456)
Fix for taskdef template after datadog integration enabled