### PR TITLE
removed all MATIC mention to POL in incentive-mechanism.md page

### DIFF
--- a/docs/zkEVM/architecture/protocol/incentive-mechanism.md
+++ b/docs/zkEVM/architecture/protocol/incentive-mechanism.md
@@ -8,7 +8,7 @@ The **native currency used in L2 is `Bridged Ether`**, which originates from L1.
 
 The Sequencer earns the transaction fees paid by L2 users for submitting transactions, and thus gets paid directly in `Bridged Ether`. The amount of fees paid depends on the gas price, which is set by users based on how much they are willing to pay for the execution of their transactions.
 
-To incentivize the Aggregator for each batch sequenced, the Sequencer must lock a number of MATIC tokens in the L1 `PolygonZkEVM.sol` Contract proportional to the number of batches in the sequence. The number of MATIC tokens locked per batch sequenced is saved in the variable `batchFee`.
+To incentivize the Aggregator for each batch sequenced, the Sequencer must lock a number of POL tokens in the L1 `PolygonZkEVM.sol` Contract proportional to the number of batches in the sequence. The number of POL tokens locked per batch sequenced is saved in the variable `batchFee`.
 
 The below diagram depicts the various fees and rewards earned by the protocol's actors.
 
@@ -21,7 +21,7 @@ Users must ensure that their transaction fees are greater than this **threshold*
 The net Ether value earned by the Sequencer for sequencing a batch sequence is represented by the following expression:
 
 $$
-\textit{`` }\mathtt{Sequencer\ net\ Ether\ income}\text{'' } \mathtt{ =\ totalL2TxGasFee − (L1SeqTxGasFees + \frac{batchFee ∗ nBatches}{MATIC/ETH})}
+\textit{`` }\mathtt{Sequencer\ net\ Ether\ income}\text{'' } \mathtt{ =\ totalL2TxGasFee − (L1SeqTxGasFees + \frac{batchFee ∗ nBatches}{POL/ETH})}
 $$
 
 where:
@@ -30,32 +30,32 @@ where:
 - `L1SeqTxGasFee` is the Sequencing transaction gas fee paid in L1,
 - `batchFee` is the storage variable in **PolygonZkEVM.sol** contract,
 - `nBatches` is the number of batches in the sequence,
-- `MATIC/ETH` is the price of MATIC token expressed in ETH.
+- `POL/ETH` is the price of POL token expressed in ETH.
 
 ## Aggregation reward
 
 The Aggregator also needs compensation for correctly fulfilling its role.
 
-The **number of MATIC tokens earned** by the Aggregator each time it aggregates a sequence, denoted by `batchReward`, is determined by the **total contract MATIC balance** and the **number of batches aggregated**.
+The **number of POL tokens earned** by the Aggregator each time it aggregates a sequence, denoted by `batchReward`, is determined by the **total contract POL balance** and the **number of batches aggregated**.
 
-The MATIC earned per batch aggregated is calculated by the L1 `PolygonZkEVM.sol` contract prior to sequence aggregation using the following expression:
+The POL earned per batch aggregated is calculated by the L1 `PolygonZkEVM.sol` contract prior to sequence aggregation using the following expression:
 
 $$
-    \mathtt{batchReward} =  { \dfrac{ \textit{``}contract\ MATIC\ balance\textit{''}}{\textit{``}Quantity\ of\ batches\ not\ aggregated\ yet \textit{''}}}
+    \mathtt{batchReward} =  { \dfrac{ \textit{``}contract\ POL\ balance\textit{''}}{\textit{``}Quantity\ of\ batches\ not\ aggregated\ yet \textit{''}}}
 $$
 
 The following expression represents **the total amount of ETH value that the Aggregator earns for the aggregation of a sequence of batches**:
 
 $$
-\mathtt{\textit{`` }Aggregator net Ether income\textit{''}= \frac{batchReward ∗ nBatches}{MATIC/ETH} − L1AggTxGasFee}
+\mathtt{\textit{`` }Aggregator net Ether income\textit{''}= \frac{batchReward ∗ nBatches}{POL/ETH} − L1AggTxGasFee}
 $$
 
 where:
 
 - `L1AggTxGasFee` is the Aggregation transaction gas fee paid in L1,
-- `batchReward` is the quantity of MATIC earned per batch aggregated,
+- `batchReward` is the quantity of POL earned per batch aggregated,
 - `nBatches` is the number of batches in the sequence,
-- `MATIC/ETH` is the price of MATIC token expressed in ETH.
+- `POL/ETH` is the price of POL token expressed in ETH.
 
 ## Variable batchFee re-adjustments
 
@@ -109,6 +109,6 @@ The graph below shows the percentage variation of the `batchFee` variable depend
 
 To summarize, the admin can tune the reaction of `batchFee` variable re-adjustments by adjusting `veryBatchTimeTarget` and `multiplierBatchFee`. The values set during the contract's initialization are listed below:
 
-- `batchFee` = 1018 (1 MATIC).
+- `batchFee` = 1018 (1 POL).
 - `veryBatchTimeTarget` = 30 minutes.
 - `multiplierBatchFee` = 1002.


### PR DESCRIPTION
I remove all mentions of MATIC token and MATIC and replaced with POL in the  incentive-mechanism.md page of the zKEVM documentation