### PR TITLE
Removed deprecated chain from the list

### DIFF
--- a/docs/agglayer/overview.md
+++ b/docs/agglayer/overview.md
@@ -18,16 +18,14 @@ Here's a list of chains connected to the alpha version of the AggLayer:
 | Startale Labs      | Astar         | 3776        | Astar zkEVM             |
 | Gateway FM         | GPT Protocol  | 1511670449  | gpt-mainnet             |
 | Gateway FM         | Haust         | 1570754601  | haust-testnet           |
-| Gateway FM         | Haust         | 999         | haust-network           |
+| Gateway FM         | Haust         | 938        | haust-network           |
 | Gateway FM         | Lumia         | 1952959480  | Lumia Testnet           |
 | Gateway FM         | Lumia         | 994873017   | prism                   |
 | Gateway FM         | Moonveil      | 1297206718  | moonveil-testnet        |
-| OKX                | OKX           | 195         | X Layer Devnet          |
 | OKX                | OKX           | 196         | X Layer                 |
 | Gateway FM         | Silicon       | 1722641160  | silicon-sepolia-testnet |
 | Gateway FM         | Silicon       | 2355        | silicon-zk              |
-| Gateway FM         | WilderWorld   | 1668201165  | zchain-testnet          |
-| Gateway FM         | Wirex         | 407985408   | wirex-pay-devnet        |
+| Gateway FM         | WilderWorld   | 1668201165  | zchain-testnet          |  
 | Gateway FM         | Wirex         | 31415       | pay-chain               |
 
 ## AggLayer components

--- a/docs/agglayer/overview.md
+++ b/docs/agglayer/overview.md
@@ -12,7 +12,7 @@ The AggLayer currently connects chains built with Polygon CDK, a developer toolk
 Here's a list of chains connected to the alpha version of the AggLayer:
 
 
-| Polygon IP Partner | Chain Partner | L2 Chain ID | Network Name            |
+| Implementation Provider | Chain Name | L2 Chain ID |Network Name           |
 | ------------------ | ------------- | ----------- | ----------------------- |
 | Startale Labs      | Astar         | 6038361     | zKyoto                  |
 | Startale Labs      | Astar         | 3776        | Astar zkEVM             |


### PR DESCRIPTION
I removed the following deprecated chain from the list
- Wirex devnet
- OKX devnet

I also updated Haust mainnet chain id to 938