### PR TITLE
Docs Update: Adding Reown as one of the available wallet tools on Polygon

### DIFF
--- a/docs/tools/wallets/appkit.md
+++ b/docs/tools/wallets/appkit.md
@@ -5,17 +5,11 @@
 
 ## Overview
 
-[Web3Modal](https://web3modal.com/) is a simple and intuitive SDK that provides a drop-in UI to enable users of any wallet to seamlessly log in to applications, offering a unified and smooth experience. It features a streamlined wallet selection interface with automatic detection of various wallet types, including mobile, extension, desktop, and web app wallets.
-
-## Code sandbox for Polygon
-
-The Web3Modal team has prepared a [Polygon Code Sandbox](https://codesandbox.io/p/sandbox/web3modal-v3-polygon-7264l5?file=/src/main.tsx:9,19-9,50). It’s a straightforward way for developers to integrate and get hands-on experience with Polygon.
+[AppKit](https://reown.com/appkit/?utm_source=polygon&utm_medium=docs&utm_campaign=backlinks) is a powerful, free, and fully open-source SDK for developers looking to integrate wallet connections and other Web3 functionalities into their apps on any EVM and non-EVM chain. In just a few simple steps, you can provide your users with seamless wallet access, one-click authentication, social logins, and notifications—streamlining their experience while enabling advanced features like on-ramp functionality, in-app token swaps and smart accounts.
 
 ## How to integrate
 
-1. **Visit Web3Modal:** Go to [Web3Modal's official website](https://web3modal.com/) to explore its features and capabilities.
-2. **Explore the Code Sandbox:** Utilize the [Polygon Code Sandbox](https://codesandbox.io/p/sandbox/web3modal-v3-polygon-7264l5?file=/src/main.tsx:9,19-9,50) to demo and understand the integration process.
-3. **Follow the Documentation:** Refer to the provided documentation and instructions to integrate Web3Modal into your projects and leverage its features effectively.
+1. **Visit Reown Docs:** Go to [Reown's official docs](https://docs.reown.com/?utm_source=polygon&utm_medium=docs&utm_campaign=backlinks) to explore its features and capabilities. Refer to the provided documentation and instructions to integrate Reown AppKit into your projects and leverage its features effectively.
 
 ## zkEVM support
 

--- a/docs/tools/wallets/reown.md
+++ b/docs/tools/wallets/reown.md
@@ -1,0 +1,26 @@
+!!!caution
+    Content disclaimer
+
+    Please view the third-party content disclaimer [here](https://github.com/0xPolygon/polygon-docs/blob/main/CONTENT_DISCLAIMER.md).
+
+## Reown (prev. known as WalletConnect)
+
+**[Reown](https://reown.com/?utm_source=polygon&utm_medium=docs&utm_campaign=backlinks)** gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure.
+
+Reown has two major product offerings, they are, **AppKit** and **WalletKit**.
+
+### AppKit
+
+AppKit is a powerful, free, and fully open-source SDK for developers looking to integrate wallet connections and other Web3 functionalities into their apps on any EVM and non-EVM chain. In just a few simple steps, you can provide your users with seamless wallet access, one-click authentication, social logins, and notifications—streamlining their experience while enabling advanced features like on-ramp functionality, in-app token swaps and smart accounts.
+
+### WalletKit
+WalletKit is a robust, open-source SDK designed to empower seamless wallet connections and interactions across any blockchain. With WalletKit, you can offer your users a simple and secure way to connect with thousands of apps, enabling features like one-click authentication, secure transaction signing, and streamlined wallet address verification. Its chain-agnostic design ensures effortless multi-chain support, eliminating the need for complex integrations while delivering unmatched connectivity and security.
+
+To summarize, **AppKit** is for **Web3 applications** and **WalletKit** is for **Web3 wallets**.
+
+You will be able to use Reown AppKit to power end-to-end wallet interactions on your Web3 app deployed on Polygon.
+
+Some links to learn more about Reown:
+- [Website](https://reown.com/?utm_source=polygon&utm_medium=docs&utm_campaign=backlinks)
+- [Blog](https://reown.com/blog?utm_source=polygon&utm_medium=docs&utm_campaign=backlinks)
+- [Docs](https://docs.reown.com/?utm_source=polygon&utm_medium=docs&utm_campaign=backlinks)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -554,8 +554,10 @@ nav:
           - Portis:  tools/wallets/portis.md    
           - Torus:  tools/wallets/torus.md  
           - WalletConnect:  tools/wallets/walletconnect.md
+          - Reown:
+              - Intro: tools/wallets/reown.md
+              - AppKit: tools/wallets/appkit.md
           - WalletKit:  tools/wallets/walletkit.md
-          - Web3Modal: tools/wallets/using-web3modal.md
         - Block explorers:
           - OKX explorer: https://www.okx.com/web3/explorer/polygon      
           - Polygon: https://polygonscan.com/ 


### PR DESCRIPTION
## Description

WalletConnect Inc. is now known as Reown. This PR adds a dedicated doc page for Reown and also updates the Web3Modal reference, which was rebranded to Reown AppKit.

## Closing Issues

Closes issue #2518 