### PR TITLE
Added deprecation warning to legacy zkevm-node setup

### DIFF
--- a/docs/zkEVM/get-started/setup-nodes/local-node.md
+++ b/docs/zkEVM/get-started/setup-nodes/local-node.md
@@ -4,6 +4,11 @@ comments: true
 ---
 -->
 
+!!! danger
+    - This zkevm-node setup is deprecated and will no longer be supported.
+    - Please migrate to the [cdk-erigon node setup](https://docs.polygon.technology/cdk/getting-started/cdk-erigon/deploy-cdk-erigon/).
+
+
 This quick start guide shows you how to deploy a zkEVM rollup stack on your local machine.
 
 It sets up and runs the following components:


### PR DESCRIPTION
The legacy zkevm-node setup was deprecated in on [v0.7.3](https://github.com/0xPolygonHermez/zkevm-node/releases/tag/v0.7.3), some users still go to try to run it. 

Hence the need for the warning and a pointer for them to instead use the cdk-erigon node setup