### PR TITLE
Update docker file to have bash so mkdocks-multibranch works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk update
 RUN apk add rsync
 RUN apk add git
 RUN apk add nodejs npm
+RUN apk add --no-cache bash
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt --no-cache-dir
 


### PR DESCRIPTION
Add `bash` to the aline docker image so that `docker compose up` will work with the multirepo plugin.