### PR TITLE
Changing the Miden docs to our new repository

### DIFF
--- a/docs/miden/index.md
+++ b/docs/miden/index.md
@@ -15,33 +15,17 @@ hide:
       <h1 class="hero-heading">Polygon Miden</h1>
       <h2><code>Software in development</code></h2>
       <h2></h2>
-      <p class="hero-subtext">Polygon Miden is a zero-knowledge rollup for private, high-throughput applications.</p>
+      <p class="hero-subtext">Polygon Miden is a zero-knowledge rollup for high-throughput, private applications.</p>
    </div>
 </div>
 
 <div class="grid-container">
    <div class="grid-item">
-      <a href="./miden-base/introduction/get-started/prerequisites/">
+      <a href="https://0xpolygonmiden.github.io/miden-docs/">
          <div class="product-list-item-header">
-            <div class="feature-card-heading">Getting started</div>
+            <div class="feature-card-heading">Miden docs</div>
          </div>
-         <p class="feature-paragraph">Follow the Miden getting started guide to get up and running.</p>
-      </a>
-   </div>
-   <div class="grid-item">
-      <a href="./miden-base/architecture/overview/">
-         <div class="product-list-item-header">
-            <div class="feature-card-heading">Miden architecture</div>
-         </div>
-         <p class="feature-paragraph">Learn more about the Miden architecture.</p>
-      </a>
-   </div>
-   <div class="grid-item">
-      <a href="./miden-base/introduction/roadmap/">
-         <div class="product-list-item-header">
-            <div class="feature-card-heading">Roadmap</div>
-         </div>
-         <p class="feature-paragraph">Check out the Miden roadmap for the latest updates.</p>
+         <p class="feature-paragraph">Learn everything about Miden.</p>
       </a>
    </div>
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -404,10 +404,7 @@ nav:
             - Meta transactions: pos/concepts/transactions/meta-transactions.md
   - Miden:
       - Miden: miden/index.md
-      - Miden base: '!import https://github.com/0xPolygonMiden/miden-base?branch=main'
-      - Miden client: '!import https://github.com/0xPolygonMiden/miden-client?branch=main'
-      - Miden compiler: '!import https://github.com/0xPolygonMiden/compiler?branch=next'
-  - Developer tools: 
+  - Developer tools:
       - Developer tools: tools/index.md
       - Start building:
         - Test token faucets: tools/gas/matic-faucet.md


### PR DESCRIPTION
This PR changes the Miden docs to our new repository. We need to make this change to have one canonical place for the Miden docs. Some parts of the docs in the knowledge layer were broken.

I was not able to build the docs locally due to. I changed the HTML of `index.md`. I think it should work, but I can push a follow-up PR if it doesn't.

```
Traceback (most recent call last):
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/mkdocs/commands/build.py", line 351, in build
    raise Abort(f'Aborted with {msg} in strict mode!')
mkdocs.exceptions.Abort: Aborted with 26 warnings in strict mode!

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/dschmid/polygon-docs/venv/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/mkdocs/__main__.py", line 272, in serve_command
    serve.serve(**kwargs)
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 85, in serve
    builder(config)
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 67, in builder
    build(config, serve_url=None if is_clean else serve_url, dirty=is_dirty)
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/mkdocs/commands/build.py", line 357, in build
    config.plugins.on_build_error(error=e)
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/mkdocs/plugins.py", line 605, in on_build_error
    return self.run_event('build_error', error=error)
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/mkdocs/plugins.py", line 568, in run_event
    result = method(**kwargs)
  File "/Users/dschmid/polygon-docs/venv/lib/python3.10/site-packages/mkdocs_multirepo_plugin/plugin.py", line 361, in on_build_error
    shutil.rmtree(str(self.temp_dir))
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/shutil.py", line 708, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/shutil.py", line 706, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/dschmid/polygon-docs/temp_dir'
```

