### PR TITLE
fix: update 404 links supra.md

### DIFF
--- a/docs/tools/oracles/supra.md
+++ b/docs/tools/oracles/supra.md
@@ -4,8 +4,8 @@
 
 **Supra** is a novel, high-throughput oracle & intralayer: A vertically integrated toolkit of cross-chain solutions (data oracles, asset bridges, automation network, and more) that interlink all blockchains, public (L1s and L2s) or private (enterprises).
 
-[Supra](https://supraoracles.com/) provides decentralized oracle price feeds that can be used for on-chain and off-chain use-cases such as spot and perpetual DEXes, lending protocols, and payments protocols. Supra’s oracle chain and consensus algorithm makes it the fastest-to-finality oracle provider, with layer-1 security guarantees. The pull oracle has a sub-second response time. Aside from speed and security, Supra’s rotating node architecture gathers data from 40+ data sources and applies a robust calculation methodology to get the most accurate value. The node provenance on the data dashboard also provides a fully transparent historical audit trail. Supra’s Distributed Oracle Agreement (DORA) paper was accepted into ICDCS 2023, the oldest distributed systems conference.
+[Supra](https://supra.com/) provides decentralized oracle price feeds that can be used for on-chain and off-chain use-cases such as spot and perpetual DEXes, lending protocols, and payments protocols. Supra’s oracle chain and consensus algorithm makes it the fastest-to-finality oracle provider, with layer-1 security guarantees. The pull oracle has a sub-second response time. Aside from speed and security, Supra’s rotating node architecture gathers data from 40+ data sources and applies a robust calculation methodology to get the most accurate value. The node provenance on the data dashboard also provides a fully transparent historical audit trail. Supra’s Distributed Oracle Agreement (DORA) paper was accepted into ICDCS 2023, the oldest distributed systems conference.
 
-Check out our [developer docs](https://supraoracles.com/docs/overview/).
+Check out our [developer docs](https://docs.supra.com/oracles/overview).
 
 


### PR DESCRIPTION
Hi! I fixes broken links in the `supra.md` file. The old links pointed to outdated or non-existent pages on the Supra website. They have been updated to the correct and current URLs.